### PR TITLE
Allow to display variant

### DIFF
--- a/flags/fr-bepo.svg
+++ b/flags/fr-bepo.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   id="svg889"
+   height="600"
+   width="900"
+   version="1.1">
+  <metadata
+     id="metadata895">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <defs
+     id="defs893" />
+  <rect
+     id="rect883"
+     style="fill:#00209F"
+     height="600"
+     width="900" />
+  <rect
+     id="rect885"
+     style="fill:#fff"
+     x="300"
+     height="600"
+     width="600" />
+  <rect
+     id="rect887"
+     style="fill:#F42A41"
+     x="600"
+     height="600"
+     width="300" />
+  <g
+     transform="matrix(1.2756601,0,0,1.2835806,-242.05053,-165.41551)"
+     id="text899"
+     style="font-style:normal;font-weight:normal;font-size:40px;line-height:1.25;font-family:sans-serif;letter-spacing:0px;word-spacing:0px;fill:#000000;fill-opacity:1;stroke:#fefefe;stroke-width:4.68891319;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     aria-label="BEPO">
+    <path
+       id="path920"
+       style="font-size:192px;stroke:#fefefe;stroke-width:4.68891319;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 406.51361,513.7478 v 51.28125 h 30.375 q 15.28125,0 22.59375,-6.28125 7.40625,-6.375 7.40625,-19.40625 0,-13.125 -7.40625,-19.3125 -7.3125,-6.28125 -22.59375,-6.28125 z m 0,-57.5625 v 42.1875 h 28.03125 q 13.875,0 20.625,-5.15625 6.84375,-5.25 6.84375,-15.9375 0,-10.59375 -6.84375,-15.84375 -6.75,-5.25 -20.625,-5.25 z m -18.9375,-15.5625 h 48.375 q 21.65625,0 33.375,9 11.71875,9 11.71875,25.59375 0,12.84375 -6,20.4375 -6,7.59375 -17.625,9.46875 13.96875,3 21.65625,12.5625 7.78125,9.46875 7.78125,23.71875 0,18.75 -12.75,28.96875 -12.75,10.21875 -36.28125,10.21875 h -50.25 z" />
+    <path
+       id="path922"
+       style="font-size:192px;stroke:#fefefe;stroke-width:4.68891319;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 519.20111,440.6228 h 88.5 v 15.9375 h -69.5625 v 41.4375 h 66.65625 v 15.9375 h -66.65625 v 50.71875 h 71.25 v 15.9375 h -90.1875 z" />
+    <path
+       id="path924"
+       style="font-size:192px;stroke:#fefefe;stroke-width:4.68891319;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 659.63861,456.1853 v 52.59375 h 23.8125 q 13.21875,0 20.4375,-6.84375 7.21875,-6.84375 7.21875,-19.5 0,-12.5625 -7.21875,-19.40625 -7.21875,-6.84375 -20.4375,-6.84375 z m -18.9375,-15.5625 h 42.75 q 23.53125,0 35.53125,10.6875 12.09375,10.59375 12.09375,31.125 0,20.71875 -12.09375,31.3125 -12,10.59375 -35.53125,10.59375 h -23.8125 v 56.25 h -18.9375 z" />
+    <path
+       id="path926"
+       style="font-size:192px;stroke:#fefefe;stroke-width:4.68891319;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 813.38861,453.46655 q -20.625,0 -32.8125,15.375 -12.09375,15.375 -12.09375,41.90625 0,26.4375 12.09375,41.8125 12.1875,15.375 32.8125,15.375 20.625,0 32.625,-15.375 12.09375,-15.375 12.09375,-41.8125 0,-26.53125 -12.09375,-41.90625 -12,-15.375 -32.625,-15.375 z m 0,-15.375 q 29.4375,0 47.0625,19.78125 17.625,19.6875 17.625,52.875 0,33.09375 -17.625,52.875 -17.625,19.6875 -47.0625,19.6875 -29.53125,0 -47.25,-19.6875 -17.625,-19.6875 -17.625,-52.875 0,-33.1875 17.625,-52.875 17.71875,-19.78125 47.25,-19.78125 z" />
+  </g>
+</svg>

--- a/panel-plugin/xkb-dialog.c
+++ b/panel-plugin/xkb-dialog.c
@@ -150,6 +150,7 @@ xkb_dialog_configure_plugin (XfcePanelPlugin *plugin,
   display_name_combo = gtk_combo_box_text_new ();
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (display_name_combo), _("country"));
   gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (display_name_combo), _("language"));
+  gtk_combo_box_text_append_text (GTK_COMBO_BOX_TEXT (display_name_combo), _("variant"));
   gtk_widget_set_size_request (display_name_combo, 230, -1);
   gtk_grid_attach (GTK_GRID (grid), display_name_combo, 1, grid_vertical, 1, 1);
 

--- a/panel-plugin/xkb-keyboard.c
+++ b/panel-plugin/xkb-keyboard.c
@@ -358,7 +358,7 @@ xkb_keyboard_initialize_xkb_options (XkbKeyboard        *keyboard,
 
       #undef MODIFY_INDEXES
 
-      imgfilename = xkb_util_get_flag_filename (group_data->country_name);
+      imgfilename = xkb_util_get_flag_filename (group_data->country_name, group_data->variant);
       handle = rsvg_handle_new_from_file (imgfilename, NULL);
       if (handle)
         {
@@ -710,6 +710,12 @@ xkb_keyboard_get_group_name (XkbKeyboard    *keyboard,
 
     case DISPLAY_NAME_LANGUAGE:
       return group_data->language_name;
+
+    case DISPLAY_NAME_VARIANT:
+      if (g_str_equal(group_data->variant, "")) {
+          return group_data->language_name;
+      }
+      return group_data->variant;
 
     default:
       return "";

--- a/panel-plugin/xkb-properties.h
+++ b/panel-plugin/xkb-properties.h
@@ -44,6 +44,7 @@ typedef enum
 {
   DISPLAY_NAME_COUNTRY            = 0,
   DISPLAY_NAME_LANGUAGE           = 1,
+  DISPLAY_NAME_VARIANT            = 2
 } XkbDisplayName;
 
 #define DISPLAY_SCALE_MIN           0

--- a/panel-plugin/xkb-util.c
+++ b/panel-plugin/xkb-util.c
@@ -25,22 +25,39 @@
 
 #include <string.h>
 
+#include <libxfce4util/libxfce4util.h>
+
 #include "xkb-util.h"
 
 
-
 gchar*
-xkb_util_get_flag_filename (const gchar* group_name)
+xkb_util_get_flag_filename (const gchar* group_name,
+                            const gchar* variant)
 {
   gchar* filename;
 
   if (!group_name)
     return NULL;
 
-  filename = g_strconcat (g_get_user_data_dir (), "/", FLAGSRELDIR, "/", group_name, ".svg", NULL);
+  filename = g_strconcat (g_get_user_data_dir (), "/", FLAGSRELDIR, "/", group_name, "-", variant, ".svg", NULL);
 
   if (!g_file_test (filename, G_FILE_TEST_EXISTS))
     {
+      DBG ("Non existent file: %s", filename);
+      g_free (filename);
+      filename = g_strconcat (g_get_user_data_dir (), "/", FLAGSRELDIR, "/", group_name, ".svg", NULL);
+    }
+
+  if (!g_file_test (filename, G_FILE_TEST_EXISTS))
+    {
+      DBG ("Non existent file: %s", filename);
+      g_free (filename);
+      filename = g_strconcat (DATADIR, "/", FLAGSRELDIR, "/", group_name, "-", variant, ".svg", NULL);
+    }
+
+  if (!g_file_test (filename, G_FILE_TEST_EXISTS))
+    {
+      DBG ("Non existent file: %s", filename);
       g_free (filename);
       filename = g_strconcat (DATADIR, "/", FLAGSRELDIR, "/", group_name, ".svg", NULL);
     }

--- a/panel-plugin/xkb-util.h
+++ b/panel-plugin/xkb-util.h
@@ -28,7 +28,8 @@
 
 #include <glib.h>
 
-gchar*      xkb_util_get_flag_filename      (const gchar   *group_name);
+gchar*      xkb_util_get_flag_filename      (const gchar   *group_name,
+                                             const gchar   *variant);
 
 gchar*      xkb_util_get_layout_string      (const gchar   *group_name,
                                              const gchar   *variant);

--- a/panel-plugin/xkb-xfconf.c
+++ b/panel-plugin/xkb-xfconf.c
@@ -108,7 +108,7 @@ xkb_xfconf_class_init (XkbXfconfClass *klass)
   g_object_class_install_property (gobject_class, PROP_DISPLAY_NAME,
                                    g_param_spec_uint (DISPLAY_NAME, NULL, NULL,
                                                       DISPLAY_NAME_COUNTRY,
-                                                      DISPLAY_NAME_LANGUAGE,
+                                                      DISPLAY_NAME_VARIANT,
                                                       DEFAULT_DISPLAY_NAME,
                                                       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 


### PR DESCRIPTION
In the same way that plugin can display country or language, allow to
display the variant (useful to differentiate FR-fr-azerty to FR-fr-bepo)