### PR TITLE
scale alternate layout dots to be visible on hi dpi displays

### DIFF
--- a/panel-plugin/xkb-cairo.c
+++ b/panel-plugin/xkb-cairo.c
@@ -83,14 +83,15 @@ xkb_cairo_draw_flag (cairo_t         *cr,
 
   if (variant_markers_count > 0)
     {
-      diameter = 5.0;
-      spacing = 1;
+      diameter = img_width/5.0;
+      if (diameter < 5.0) diameter = 5.0;
+      spacing = diameter * 0.2;
 
       /* check if the flag is too small to draw variant markers inside it */
       if ((diameter + spacing) * (max_variant_markers_count-1) > img_width - 2)
         {
           /* draw markers below the flag */
-          diameter = 4;
+          diameter *= 0.8;
           spacing = 0;
           layoutx = actual_width / 2 + (max_variant_markers_count - 2) * diameter / 2;
           layouty = (actual_height + img_height) / 2 + diameter + 1;


### PR DESCRIPTION
Currently, the dots that the xkb panel plugin adds to the flags to indicate the 2nd/3rd.. variant of a layout corresponding to the same country become so tiny as to be practically invisible on a high DPI display. This change causes them to scale automatically with the image size of the flag.