### PR TITLE
 Implement list of window class names that default to each layout 

### DIFF
--- a/README
+++ b/README
@@ -11,10 +11,12 @@ use to switch between the layouts, the actual keyboard layouts,
 the way in which the current layout is being displayed (country
 flag image or text) and the layout policy, which is whether to
 store the layout globally (for all windows), per application or
-per window.
+per window. If the policy is per application or per window, then
+for each layout you can specify a comma-separated list of window
+class names which will default to using that layout.
 
-If a certain flag is missing, the plugin will fallback to
-displaying the layout as text.
+If a certain country's flag is missing, the plugin will fallback
+to displaying the layout as text.
 
 The plugin detects any change in the layout configuration
 (e.g. setxkbmap invocations) and reconfigures itself to use
@@ -25,16 +27,6 @@ outline in the bottom right corner of the flag image if the
 current layout is the second variant configured for some
 language. If the display mode is set to "text" then a little
 dot is displayed as a subscript of the layout text.
-
-There is a hidden (not available in the GUI) setting -
-"never_modify_config". If this setting is set to "true" in
-the configuration file, then the plugin will not modify the
-layout configuration under any circumstances (currently
-even when the configuration is modified through the settings
-dialog). This option is for users who wish to configure
-some XKB options, which are not present in the GUI and thus
-are limited by the plugin. These users can use the plugin
-so that it only displays the active layouts.
 
 Known limitations and bugs
 ==========================

--- a/panel-plugin/xkb-properties.h
+++ b/panel-plugin/xkb-properties.h
@@ -32,6 +32,11 @@
 #define CAPS_LOCK_INDICATOR         "caps-lock-indicator"
 #define DISPLAY_TOOLTIP_ICON        "display-tooltip-icon"
 #define GROUP_POLICY                "group-policy"
+#define LAYOUT1_DEFAULTS            "layout1-defaults"
+#define LAYOUT2_DEFAULTS            "layout2-defaults"
+#define LAYOUT3_DEFAULTS            "layout3-defaults"
+#define MAX_LAYOUTS                 4
+
 
 typedef enum
 {

--- a/panel-plugin/xkb-xfconf.c
+++ b/panel-plugin/xkb-xfconf.c
@@ -36,6 +36,7 @@
 #define DEFAULT_CAPS_LOCK_INDICATOR         TRUE
 #define DEFAULT_DISPLAY_TOOLTIP_ICON        TRUE
 #define DEFAULT_GROUP_POLICY                GROUP_POLICY_PER_APPLICATION
+#define DEFAULT_LAYOUT_DEFAULTS             ""
 
 static void            xkb_xfconf_finalize            (GObject          *object);
 static void            xkb_xfconf_get_property        (GObject          *object,
@@ -62,6 +63,7 @@ struct _XkbXfconf
   gboolean             caps_lock_indicator;
   gboolean             display_tooltip_icon;
   XkbGroupPolicy       group_policy;
+  GString              *layout_defaults[MAX_LAYOUTS];
 };
 
 enum
@@ -73,6 +75,9 @@ enum
   PROP_CAPS_LOCK_INDICATOR,
   PROP_DISPLAY_TOOLTIP_ICON,
   PROP_GROUP_POLICY,
+  PROP_LAYOUT1_DEFAULTS,
+  PROP_LAYOUT2_DEFAULTS,
+  PROP_LAYOUT3_DEFAULTS,
   N_PROPERTIES,
 };
 
@@ -136,6 +141,21 @@ xkb_xfconf_class_init (XkbXfconfClass *klass)
                                                       DEFAULT_GROUP_POLICY,
                                                       G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_LAYOUT1_DEFAULTS,
+				   g_param_spec_string (LAYOUT1_DEFAULTS, NULL, NULL,
+							DEFAULT_LAYOUT_DEFAULTS,
+							G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_LAYOUT2_DEFAULTS,
+				   g_param_spec_string (LAYOUT2_DEFAULTS, NULL, NULL,
+							DEFAULT_LAYOUT_DEFAULTS,
+							G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
+  g_object_class_install_property (gobject_class, PROP_LAYOUT3_DEFAULTS,
+				   g_param_spec_string (LAYOUT3_DEFAULTS, NULL, NULL,
+							DEFAULT_LAYOUT_DEFAULTS,
+							G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   xkb_xfconf_signals[CONFIGURATION_CHANGED] =
     g_signal_new (g_intern_static_string ("configuration-changed"),
                   G_TYPE_FROM_CLASS (gobject_class),
@@ -150,12 +170,18 @@ xkb_xfconf_class_init (XkbXfconfClass *klass)
 static void
 xkb_xfconf_init (XkbXfconf *config)
 {
+  guint i;
+
   config->display_type = DEFAULT_DISPLAY_TYPE;
   config->display_name = DEFAULT_DISPLAY_NAME;
   config->display_scale = DEFAULT_DISPLAY_SCALE;
   config->caps_lock_indicator = DEFAULT_CAPS_LOCK_INDICATOR;
   config->display_tooltip_icon = DEFAULT_DISPLAY_TOOLTIP_ICON;
   config->group_policy = DEFAULT_GROUP_POLICY;
+  for (i=1; i < MAX_LAYOUTS; ++i) {
+    config->layout_defaults[i] = g_string_sized_new(256);
+    g_string_assign (config->layout_defaults[i], DEFAULT_LAYOUT_DEFAULTS);
+  }
 }
 
 
@@ -163,7 +189,13 @@ xkb_xfconf_init (XkbXfconf *config)
 static void
 xkb_xfconf_finalize (GObject *object)
 {
+  XkbXfconf *config = XKB_XFCONF (object);
+  guint i;
+
   xfconf_shutdown ();
+  for (i=1; i < MAX_LAYOUTS; ++i) {
+    g_string_free (config->layout_defaults[i], TRUE);
+  }
   G_OBJECT_CLASS (xkb_xfconf_parent_class)->finalize (object);
 }
 
@@ -203,6 +235,18 @@ xkb_xfconf_get_property (GObject    *object,
       g_value_set_uint (value, config->group_policy);
       break;
 
+    case PROP_LAYOUT1_DEFAULTS:
+      g_value_set_string (value, config->layout_defaults[1]->str);
+      break;
+
+    case PROP_LAYOUT2_DEFAULTS:
+      g_value_set_string (value, config->layout_defaults[2]->str);
+      break;
+
+    case PROP_LAYOUT3_DEFAULTS:
+      g_value_set_string (value, config->layout_defaults[3]->str);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -220,6 +264,14 @@ xkb_xfconf_set_property (GObject      *object,
   XkbXfconf *config = XKB_XFCONF (object);
   guint      val_uint;
   gboolean   val_boolean;
+  guint      layout;
+  GString   *val_string;
+  const gchar *prop_names[MAX_LAYOUTS];
+
+  layout = 1;
+  prop_names[1] = LAYOUT1_DEFAULTS;
+  prop_names[2] = LAYOUT2_DEFAULTS;
+  prop_names[3] = LAYOUT3_DEFAULTS;
 
   switch (prop_id)
     {
@@ -283,6 +335,20 @@ xkb_xfconf_set_property (GObject      *object,
         }
       break;
 
+    case PROP_LAYOUT3_DEFAULTS:
+      ++layout; /* FALL THROUGH */
+    case PROP_LAYOUT2_DEFAULTS:
+      ++layout; /* FALL THROUGH */
+    case PROP_LAYOUT1_DEFAULTS:
+      val_string = g_string_new (g_value_get_string (value));
+      if (!g_string_equal (val_string, config->layout_defaults[layout])) {
+	g_string_assign (config->layout_defaults[layout], val_string->str);
+	g_object_notify (G_OBJECT (config), prop_names[layout]);
+	g_signal_emit (G_OBJECT (config), xkb_xfconf_signals[CONFIGURATION_CHANGED], 0);
+      } 
+      g_string_free (val_string, TRUE);
+      break;
+
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -344,6 +410,12 @@ xkb_xfconf_get_group_policy (XkbXfconf *config)
 }
 
 
+const gchar *
+xkb_xfconf_get_layout_defaults (XkbXfconf     *config, guint layout)
+{
+  g_return_val_if_fail (IS_XKB_XFCONF (config), DEFAULT_LAYOUT_DEFAULTS);
+  return config->layout_defaults[layout]->str;
+}
 
 XkbXfconf *
 xkb_xfconf_new (const gchar *property_base)
@@ -380,6 +452,18 @@ xkb_xfconf_new (const gchar *property_base)
 
       property = g_strconcat (property_base, "/" GROUP_POLICY, NULL);
       xfconf_g_property_bind (channel, property, G_TYPE_UINT, config, GROUP_POLICY);
+      g_free (property);
+
+      property = g_strconcat (property_base, "/" LAYOUT1_DEFAULTS, NULL);
+      xfconf_g_property_bind (channel, property, G_TYPE_STRING, config, LAYOUT1_DEFAULTS);
+      g_free (property);
+
+      property = g_strconcat (property_base, "/" LAYOUT2_DEFAULTS, NULL);
+      xfconf_g_property_bind (channel, property, G_TYPE_STRING, config, LAYOUT2_DEFAULTS);
+      g_free (property);
+
+      property = g_strconcat (property_base, "/" LAYOUT3_DEFAULTS, NULL);
+      xfconf_g_property_bind (channel, property, G_TYPE_STRING, config, LAYOUT3_DEFAULTS);
       g_free (property);
     }
 

--- a/panel-plugin/xkb-xfconf.h
+++ b/panel-plugin/xkb-xfconf.h
@@ -48,6 +48,7 @@ guint           xkb_xfconf_get_display_scale               (XkbXfconf     *confi
 gboolean        xkb_xfconf_get_caps_lock_indicator         (XkbXfconf     *config);
 gboolean        xkb_xfconf_get_display_tooltip_icon        (XkbXfconf     *config);
 XkbGroupPolicy  xkb_xfconf_get_group_policy                (XkbXfconf     *config);
+const gchar *   xkb_xfconf_get_layout_defaults             (XkbXfconf     *config, guint layout);
 
 G_END_DECLS
 


### PR DESCRIPTION
Currently, even if the group policy is per_window or per_application, all windows or applications (respectively) that this plugin encounters for the first time default to the first layout on the list, layout 0 (i.e. group 0). This pull request adds a feature whereby one can specify for each of the other layouts (1, 2, or 3), a comma-separated list of window class names which will default to using that layout. (A new window is given the layout corresponding to the first layout of 1, 2, or 3 for which its class name appears on this default list, or layout 0 if there are no matches.) This allows the user to have particular applications come up immediately using specific keyboard layouts, without having to manually switch to them each time the application is started.